### PR TITLE
Change music track to master for reconnecting music

### DIFF
--- a/src/main/java/me/aoelite/bungee/autoreconnect/LimboDimensionType.java
+++ b/src/main/java/me/aoelite/bungee/autoreconnect/LimboDimensionType.java
@@ -258,7 +258,7 @@ public class LimboDimensionType {
 		music.add("sound", new StringTag(plugin.getConfig().getReconnectingMusic()));
 		music.add("max_delay", new IntTag(1));
 		music.add("min_delay", new IntTag(0));
-		effects.add("music", music);
+		effects.add("music", master);
 		
 		element.add("effects", effects);
 		


### PR DESCRIPTION
solves https://github.com/AoElite/AutoReconnect/issues/43

It's my very first time playing around with this and I truly hope it works 😂 

Most people have their music set to 0%, making it impossible to hear the reconnecting music I set in the config.

I feel like the music should be moved from the "music" track to "master", or at least make it configurable, so that no matter the player's settings, they will hear the music unless their whole game is muted.

Thanks for considering! :)

